### PR TITLE
Add support for GCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 results
 results_test
 work
+nextflow

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   - [Running the pipeline on MacOS](#running-the-pipeline-on-macos)
   - [Specifying input sequencing files](#specifying-input-sequencing-files)
   - [Testing the pipeline](#testing-the-pipeline)
+    - [Locally](#locally)
+    - [On Google Cloud Platform (GCP) Batch](#on-google-cloud-platform-gcp-batch)
   - [Launching the pipeline directly from the csgenetic/csgenetics\_scrnaseq Github repo](#launching-the-pipeline-directly-from-the-csgeneticcsgenetics_scrnaseq-github-repo)
     - [Updating the pipeline](#updating-the-pipeline)
     - [Specifying a pipeline version](#specifying-a-pipeline-version)
@@ -21,6 +23,7 @@
   - [Available standard profiles](#available-standard-profiles)
     - [test](#test)
     - [test\_singularity](#test_singularity)
+    - [gcp\_test](#gcp_test)
     - [docker](#docker)
     - [singularity](#singularity)
   - [Available curated genomic resources](#available-curated-genomic-resources)
@@ -147,6 +150,8 @@ Sample2,/home/example_user/analysis/raw_reads/example_Sample2_L001_R1_001.fastq.
 
 ## Testing the pipeline
 
+### Locally
+
 To test that your environment is set up correctly, the pipeline can be run using the `test` profile:
 
 ```bash
@@ -157,6 +162,57 @@ The test proile will run using a set of remotely hosted resources. By default, t
 
 For a full list of the configurable parameters that can be can be supplied to the pipeline
 and other options for configuration see [Configurable parameters](#configurable-parameters).
+
+### On Google Cloud Platform (GCP) Batch
+
+To execute the pipeline on Google Cloud Batch, edit the `nextflow.config`, create a repository to hold the run image, then edit and execute the `launch_gcp.sh` script by following the instructions below: 
+
+1. Under `params` in `nextflow.config`, point the `outdir` and `workDir` folders to the appropriate Google Cloud bucket:
+
+    ```
+    params {
+      ...
+      // The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.
+      outdir = 'gs://<bucket-name>/results'
+      workDir = 'gs://<bucket-name>/work'
+      ...
+    }
+    ```
+
+    Then define the Google project and region:
+
+    ```
+    params {
+      ...
+      // GCP Batch
+      googleproject = '<google-project-id>'
+      googleregion = '<google-region>' # use same region as bucket
+      ...
+    }
+    ```
+
+2. Create a docker repository (\<repository-name>) in your project using Google's Artifact Registry. A docker image is used to launch your nextflow run through Google Cloud Batch.
+
+3. Edit the variables at the top of `launch_gcp.sh`, using the same `<google-project-id>` and `<google-region>` as used in step 1, and the repository created in step 2: 
+
+    ```bash
+    #!/bin/bash
+
+    ## Define GCP parameters
+    GCP_PROJECT="<google-project-id>"
+    GCP_REGION="<google-region>" # use same region as bucket
+    GCP_REPO="<repository-name>"
+    GCP_REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}"
+
+    ## Define image names
+    RUN_NAME="<run-name>" # Must be lowercase, no underscores
+    IMAGE_NAME="${GCP_REPO}-nextflow-run:${RUN_NAME}"
+    GCP_IMAGE="${GCP_REGISTRY}/${IMAGE_NAME}"
+    ```
+
+4. Launch the script by executing `./launch_gcp.sh`. This will build and push the docker image containing your nextflow run configuration to the Artifact registry, then deploy the run to Google Cloud Batch on a light-weight head node with the `<run-name>` you defined in step 3.
+
+    You can monitor the status of your run and inspect the logs through the Google Cloud Batch web interface. The `results` and `work` should appear in the storage bucket defined in step 1.
 
 <div style="text-align: right"><a href="#cs-genetics-scrna-seq-pipeline">top</a></div>
 
@@ -270,6 +326,10 @@ E.g.
 ```bash
 nextflow run main.nf -profile test_singularity
 ```
+
+### gcp_test
+
+See [Testing the pipeline > On Google Cloud Platform (GCP) Batch](#on-google-cloud-platform-gcp-batch) for detailed instructions on how to run the test on Google Cloud Platform.
 
 ### docker
 

--- a/conf/gcp.config
+++ b/conf/gcp.config
@@ -1,0 +1,8 @@
+google {
+  project = "${params.googleproject}"
+  region = "${params.googleregion}"
+}
+
+process {
+  executor = 'google-batch'
+}

--- a/images/gcp_launch/Dockerfile
+++ b/images/gcp_launch/Dockerfile
@@ -1,0 +1,12 @@
+# Build the image for running nextflow
+FROM nextflow/nextflow:24.04.3
+
+## Use root & switch context to /app directory
+USER root
+WORKDIR /app
+
+## Copy the modified repo from the current working directory
+COPY ./ /app/csgenetics_scrnaseq
+
+## Run the nextflow pipeline
+CMD ["nextflow", "run", "/app/csgenetics_scrnaseq/main.nf", "-profile", "gcp_test", "-resume"]

--- a/launch_gcp.sh
+++ b/launch_gcp.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+## Define GCP parameters
+GCP_PROJECT="eric-sandbox-421120"
+GCP_REGION="us-central1"
+GCP_REGISTRY="us-central1-docker.pkg.dev/eric-sandbox-421120/csgenetics"
+
+## Define image names
+RUN_NAME="nextflow-run-test" # Must be lowercase, no underscores
+IMAGE_NAME="csgenetics-nextflow-run:${RUN_NAME}"
+GCP_IMAGE="${GCP_REGISTRY}/${IMAGE_NAME}"
+
+## Build image locally
+docker build --no-cache -t ${IMAGE_NAME} -f images/gcp_launch/Dockerfile .
+
+## Tag and push to GCP
+docker tag ${IMAGE_NAME} ${GCP_IMAGE}
+docker push ${GCP_IMAGE}
+
+## Run batch job
+echo "Running batch job..."
+gcloud beta batch jobs submit ${RUN_NAME} --project ${GCP_PROJECT} --location ${GCP_REGION} --config - <<EOD
+{
+  "name": "projects/${GCP_PROJECT}/locations/${GCP_REGION}/jobs/${RUN_NAME}",
+  "taskGroups": [
+    {
+      "taskCount": "1",
+      "parallelism": "1",
+      "taskSpec": {
+        "computeResource": {
+          "cpuMilli": "1000",
+          "memoryMib": "512"
+        },
+        "runnables": [
+          {
+            "container": {
+              "imageUri": "${GCP_IMAGE}",
+              "entrypoint": "",
+              "volumes": []
+            }
+          }
+        ],
+        "volumes": []
+      }
+    }
+  ],
+  "allocationPolicy": {
+    "instances": [
+      {
+        "policy": {
+          "provisioningModel": "STANDARD",
+          "machineType": "e2-micro"
+        }
+      }
+    ]
+  },
+  "logsPolicy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}
+EOD

--- a/launch_gcp.sh
+++ b/launch_gcp.sh
@@ -3,11 +3,12 @@
 ## Define GCP parameters
 GCP_PROJECT="eric-sandbox-421120"
 GCP_REGION="us-central1"
-GCP_REGISTRY="us-central1-docker.pkg.dev/eric-sandbox-421120/csgenetics"
+GCP_REPO="csgenetics"
+GCP_REGISTRY="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${GCP_REPO}"
 
 ## Define image names
 RUN_NAME="nextflow-run-test" # Must be lowercase, no underscores
-IMAGE_NAME="csgenetics-nextflow-run:${RUN_NAME}"
+IMAGE_NAME="${GCP_REPO}-nextflow-run:${RUN_NAME}"
 GCP_IMAGE="${GCP_REGISTRY}/${IMAGE_NAME}"
 
 ## Build image locally

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,6 +21,7 @@ params {
   input_csv = null
   // The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.
   outdir = './results'
+  workDir = './work'
 
   // Path to the comma-separated file containing the list of CS Genetics cell barcodes
   barcode_list_path = "s3://csgx.public.readonly/resources/barcode_lists/IDT_IO_kit_v2.csv"
@@ -55,6 +56,10 @@ params {
   // AWS Batch
   awsregion = null
   awsqueue = null
+
+  // GCP Batch
+  googleproject = null
+  googleregion = null
 
   // Default maximum resource limits for individual processes (expected to be overwritten)
   max_memory = 256.GB
@@ -126,6 +131,19 @@ profiles {
     includeConfig 'conf/base.config'
     includeConfig 'conf/genomes.config'
     includeConfig 'conf/aws.config'
+  }
+  gcp_test{
+    // Load base.config by default for all pipelines
+    // N.B. the base.config includeConfig has to be
+    // within each of the profile blocks else the
+    // resource allocation will not work properly
+    includeConfig 'conf/base.config'
+    includeConfig 'conf/genomes.config'
+    includeConfig 'conf/test.config'
+    includeConfig 'conf/images.config'
+    includeConfig 'conf/gcp.config'
+    docker.enabled=true
+    docker.runOptions = '-u $(id -u):$(id -g)'
   }
 
   // Species profiles


### PR DESCRIPTION
Adding profile to support pipeline execution on Google Cloud Platform (GCP) Batch.

Overview of changes:
- Profile `gcp_test` for testing pipeline using GCP.
- `gcp.config` with the appropriate configuration for running nextflow on GCP.
- Changes to `nextflow.config` for adding GCP parameters.
- Dockerfile under `images/gcp_launch` is used to execute a run on GCP.
- `launch_gcp.sh` a convenience script that automates the build and push of the run image to a GCP repository and launches a GCP Batch job.
- Updates to `README.md` detailing how to run the test profile on GCP.