### PR TITLE
Barode correction

### DIFF
--- a/bin/whitelist.awk
+++ b/bin/whitelist.awk
@@ -1,0 +1,32 @@
+BEGIN {
+    OFS="\t"; # Set output field separator to tab
+}
+
+{
+    original = $1; # Read the original barcode from the first column
+    modified = ""; # Initialize the modified string
+
+    # Iterate over each character of the original barcode
+    for (i = 1; i <= length(original); i++) {
+        # Extract the current character
+        char = substr(original, i, 1);
+
+        # Iterate over the replacement characters
+        for (replacement in replacements) {
+            # Skip if the replacement character is the same as the original character
+            if (char == replacements[replacement]) continue;
+
+            # Generate the modified barcode with the current character replaced
+            if (modified != "") modified = modified ",";
+            modified = modified substr(original, 1, i - 1) replacements[replacement] substr(original, i + 1);
+        }
+    }
+
+    # Print the original barcode and the comma-separated list of modified barcodes
+    print original, modified;
+}
+
+# Define the replacement characters
+BEGIN {
+    split("N A C T G", replacements);
+}

--- a/conf/images.config
+++ b/conf/images.config
@@ -7,7 +7,7 @@ process {
     withName: features_file         { container = 'quay.io/biocontainers/gtfparse:1.2.1--pyh864c0ab_0'}
     withName: merge_lanes           { container = 'ubuntu:bionic'}
     withName: merged_fastp          { container = 'quay.io/biocontainers/fastp:0.23.1--h79da9fb_0' }
-    withName: io_extract            { container = 'quay.io/csgenetics/gawk:0.1' }
+    withName: io_extract            { container = 'quay.io/csgenetics/umi-tools-csgx:0.9' }
     withName: io_extract_fastp      { container = 'quay.io/biocontainers/fastp:0.23.1--h79da9fb_0' }
     withName: trim_extra_polya      { container = 'quay.io/csgenetics/gawk:0.1' }
     withName: post_polyA_fastp      { container = 'quay.io/biocontainers/fastp:0.23.1--h79da9fb_0' }

--- a/main.nf
+++ b/main.nf
@@ -171,8 +171,8 @@ workflow {
   ch_merged_fastp_multiqc = merged_fastp.out.merged_fastp_multiqc
 
   // Get the barcode_list and extract the IOs from the fastqs using umitools
-  io_extract_script = "${baseDir}/bin/io_extract.awk"
-  io_extract(io_extract_in_ch, barcode_list, io_extract_script)
+  io_extract_script = "${baseDir}/bin/whitelist.awk"
+  io_extract(ch_merge_lanes_out, barcode_list, io_extract_script)
   ch_io_extract_out = io_extract.out.io_extract_out
 
   // Trim and remove low quality reads with fastp

--- a/main.nf
+++ b/main.nf
@@ -171,8 +171,8 @@ workflow {
   ch_merged_fastp_multiqc = merged_fastp.out.merged_fastp_multiqc
 
   // Get the barcode_list and extract the IOs from the fastqs using umitools
-  io_extract_script = "${baseDir}/bin/whitelist.awk"
-  io_extract(ch_merge_lanes_out, barcode_list, io_extract_script)
+  create_whitelist_script = "${baseDir}/bin/whitelist.awk"
+  io_extract(ch_merge_lanes_out, barcode_list, create_whitelist_script)
   ch_io_extract_out = io_extract.out.io_extract_out
 
   // Trim and remove low quality reads with fastp

--- a/modules/processes.nf
+++ b/modules/processes.nf
@@ -161,7 +161,7 @@ process io_extract {
   input:
   tuple val(sample_id), path(r1), path(r2)
   path(barcode_list)
-  path(io_extract_script)
+  path(create_whitelist_script)
 
   output:
   tuple val(sample_id), path("${sample_id}.io_extract.R1.fastq.gz"), emit: io_extract_out
@@ -171,7 +171,7 @@ process io_extract {
   # Format barcode file
   cut -d ',' -f 2 ${barcode_list} > barcode_list.tsv
   # Manually create umi-tools compatible whitelist with all barcodes + alts with 1 edit distance
-  awk -f ${io_extract_script} barcode_list.tsv > modified_barcode_list.tsv
+  awk -f ${create_whitelist_script} barcode_list.tsv > modified_barcode_list.tsv
 
   # UMI-tools expects the io to be the stdin, so we set this to r2, and read2-in to r1
   umi_tools extract --stdin=${r2} --read2-in=${r1} --whitelist=modified_barcode_list.tsv -L ${sample_id}_io_extract.log --bc-pattern="CCCCCCCCCCCCC" --error-correct-cell --read2-out="${sample_id}_R1.io_extract.fastq.gz"
@@ -191,18 +191,6 @@ process io_extract {
     touch ${sample_id}_R1.io_extract.fastq && gzip ${sample_id}_R1.io_extract.fastq
   fi
   """
-
-  // """
-  // cat $barcode_list | cut -d ',' -f2 > barcode_list.txt
-  // gawk -v r2=${r2} -v bc_length=13 -f $io_extract_script barcode_list.txt <(zcat ${r1})
-  // # Check if the output file exists and rename it to the sample_id
-  // # If it doesn't exist, create an empty file
-  // if [ -f "io_extract.good.R1.fastq.gz" ]; then
-  //   mv io_extract.good.R1.fastq.gz ${sample_id}_R1.io_extract.fastq.gz
-  // else
-  //   touch ${sample_id}_R1.io_extract.fastq && gzip ${sample_id}_R1.io_extract.fastq
-  // fi
-  // """
 }
 
 /*

--- a/modules/processes.nf
+++ b/modules/processes.nf
@@ -168,14 +168,41 @@ process io_extract {
 
   script:
   """
-  cat $barcode_list | cut -d ',' -f2 > barcode_list.txt
-  gawk -v r2=${r2} -v sample_id=${sample_id} -v bc_length=13 -f $io_extract_script barcode_list.txt <(zcat ${r1})
+  # Format barcode file
+  cut -d ',' -f 2 ${barcode_list} > barcode_list.tsv
+  # Manually create umi-tools compatible whitelist with all barcodes + alts with 1 edit distance
+  awk -f ${io_extract_script} barcode_list.tsv > modified_barcode_list.tsv
 
-  # If it doesn't exist, create an empty file to collect
-  if [ ! -f "${sample_id}.io_extract.R1.fastq.gz" ]; then
-    touch ${sample_id}.io_extract.R1.fastq && gzip ${sample_id}.io_extract.R1.fastq
+  # UMI-tools expects the io to be the stdin, so we set this to r2, and read2-in to r1
+  umi_tools extract --stdin=${r2} --read2-in=${r1} --whitelist=modified_barcode_list.tsv -L ${sample_id}_io_extract.log --bc-pattern="CCCCCCCCCCCCC" --error-correct-cell --read2-out="${sample_id}_R1.io_extract.fastq.gz"
+  
+  # Get number of reads passing filter from log and write to file
+  if [ -f "${sample_id}_io_extract.log" ]; then
+    grep "Reads output:" ${sample_id}_io_extract.log | cut -d' ' -f4- > io_extract.log
+  else
+    echo "Reads output: 0" > io_extract.log
+  fi
+
+  # Check if the output file exists
+  # If it doesn't exist, create an empty file
+  if [ -f "${sample_id}_R1.io_extract.fastq.gz" ]; then
+    echo "${sample_id}_R1.io_extract.fastq.gz file exists"
+  else
+    touch ${sample_id}_R1.io_extract.fastq && gzip ${sample_id}_R1.io_extract.fastq
   fi
   """
+
+  // """
+  // cat $barcode_list | cut -d ',' -f2 > barcode_list.txt
+  // gawk -v r2=${r2} -v bc_length=13 -f $io_extract_script barcode_list.txt <(zcat ${r1})
+  // # Check if the output file exists and rename it to the sample_id
+  // # If it doesn't exist, create an empty file
+  // if [ -f "io_extract.good.R1.fastq.gz" ]; then
+  //   mv io_extract.good.R1.fastq.gz ${sample_id}_R1.io_extract.fastq.gz
+  // else
+  //   touch ${sample_id}_R1.io_extract.fastq && gzip ${sample_id}_R1.io_extract.fastq
+  // fi
+  // """
 }
 
 /*


### PR DESCRIPTION
Implement barcode correction at io_extract step:
- updated io_extract process to run new scripts bin/whitelist.awk, which creates a 1 edit-dist barcode list from the input barcode list
- io extraction now taken care of by umitoools extract which extracts the io barcode from the read, checks if it matches the 1 edit-dist barcode list, corrects the barcode if necessary, and writes the matching reads to fq.gz
- Also creates a log file containing nnumber of reads passing the filter, but this isn't used downstream at the moment so isn't explicitly output by the process

These commits are pulled in from the private repo, I accidently included the bump version commit and couldn't figure out how to fix that post-hoc so apologies for the unsquashed and superfluous commits.