### PR TITLE
handle missing input files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -75,13 +75,13 @@ workflow {
     if (checkPathExists(params.star_index)) {
       star_index = download_star_index()
     } else {
-      throw new RuntimeException("The specified STAR index ${params.star_index} does not exist.")
+      throw new RuntimeException("The specified S3 STAR index ${params.star_index} does not exist.")
     }
   } else {
     if (checkPathExists(params.star_index)) {
       star_index = file(params.star_index)
     } else {
-      throw new RuntimeException("The specified STAR index ${params.star_index} does not exist.")
+      throw new RuntimeException("The specified local STAR index ${params.star_index} does not exist.")
     }
     
   }
@@ -92,13 +92,13 @@ workflow {
     if (checkPathExists(params.gtf)) {
       gtf = download_gtf()
     } else {
-      throw new RuntimeException("The specified GTF file ${params.gtf} does not exist.")
+      throw new RuntimeException("The specified S3 GTF file ${params.gtf} does not exist.")
     }
   } else {
     if (checkPathExists(params.gtf)) {
       gtf = file(params.gtf)
     } else {
-      throw new RuntimeException("The specified GTF file ${params.gtf} does not exist.")
+      throw new RuntimeException("The specified local GTF file ${params.gtf} does not exist.")
     }
   }
 
@@ -108,13 +108,13 @@ workflow {
     if (checkPathExists(params.input_csv)) {
       input_csv = download_input_csv()
     } else {
-      throw new RuntimeException("The specified input_csv file ${params.input_csv} does not exist.")
+      throw new RuntimeException("The specified S3 input_csv file ${params.input_csv} does not exist.")
     }
   } else {
     if (checkPathExists(params.input_csv)) {
       input_csv = Channel.fromPath(params.input_csv)
     } else {
-      throw new RuntimeException("The specified input_csv file ${params.input_csv} does not exist.")
+      throw new RuntimeException("The specified local input_csv file ${params.input_csv} does not exist.")
     }
   }
   
@@ -151,7 +151,7 @@ workflow {
         if (checkPathExists(fastq_1) && checkPathExists(fastq_2)) {
             return row
         } else {
-            throw new RuntimeException("One or both of the fastq files specified in ${params.input_csv} do not exist: ${fastq_1}, ${fastq_2}")
+            throw new RuntimeException("One or both of the s3 fastq files specified in ${params.input_csv} do not exist: ${fastq_1}, ${fastq_2}")
         }
     }
     .set { to_download_ch }

--- a/main.nf
+++ b/main.nf
@@ -74,6 +74,7 @@ workflow {
   if (params.star_index.startsWith("s3://csgx.public.readonly")){
     println "Detected S3 path: ${params.star_index}"
     if (checkPathExists(params.star_index)) {
+      println "Valid S3 path found: ${params.star_index}"
       star_index = download_star_index()
     } else {
       throw new RuntimeException("The specified S3 STAR index ${params.star_index} does not exist.")

--- a/main.nf
+++ b/main.nf
@@ -72,18 +72,19 @@ workflow {
   // Check whether params.star_index starts with s3://csgx.public.readonly
   // and if it does, download the file in a process and set the star_index to the downloaded file
   if (params.star_index.startsWith("s3://csgx.public.readonly")){
+    println "Detected S3 path: ${params.star_index}"
     if (checkPathExists(params.star_index)) {
       star_index = download_star_index()
     } else {
       throw new RuntimeException("The specified S3 STAR index ${params.star_index} does not exist.")
     }
   } else {
+    println "Detected local path: ${params.star_index}"
     if (checkPathExists(params.star_index)) {
       star_index = file(params.star_index)
     } else {
       throw new RuntimeException("The specified local STAR index ${params.star_index} does not exist.")
-    }
-    
+    } 
   }
   
   // Check whether params.gtf starts with s3://csgx.public.readonly


### PR DESCRIPTION
Aim to check that input files (star, gtf, input_csv, fqs) exist before running any processes that require them.
This way the pipeline fails right at the start and with an informative error message, instead of the process failing and being retried.

Added functions to main to check if path exists on local system or on s3.
Called these functions conditionally before running the relevant process, so if the file exists the process will be run. If it doesn't the pipeline fails with an error.

Should make the pipeline fail faster in case of human error with any of the file paths, or if templates/scripts get accidentally deleted