### PR TITLE
Adding barnyard plots to summary reports plus move to plotly for cell caller plots

### DIFF
--- a/bin/cell_caller.py
+++ b/bin/cell_caller.py
@@ -7,13 +7,16 @@ import matplotlib.pyplot as plt
 from scipy.signal import argrelextrema
 from scipy.stats import gaussian_kde
 import sys, argparse
+import plotly.express as px
+import plotly.graph_objects as go
+import plotly.io as pio
 
 """
 This is the cell caller function.
 It operates on the distribution of total counts for cellular barcodes.
 
-This function reads in an anndata object (h5ad), gets the total counts per cellular barcode,  
-log10 + 1 transforms the counts and evaluates the density distribution of those transformed counts.
+This function reads in an anndata object (h5ad), gets the total counts per cellular barcode,
+transforms the counts according to log10(counts + 1) and evaluates the density distribution of those transformed counts.
 The transformation is necessary to condense the data enough to get a noise peak and a single-cell peak.
 When values are untransformed, there's too much spread to identify the populations.
 
@@ -27,7 +30,7 @@ would be called as a cell.
 If there are no local minima above the minimum_count_threshold, then the function will 
 next look for inflection points above the minimum_count_threshold where the gradient is 
 close to 0. If there are none of these either, then the function will default to the minimum_count_threshold. 
-This is generally set to 100 i.e. 2 on the log10 scale.
+This is generally set to 100.
 
 If working with mixed species it identifies two sub-populations of barcodes: those with Mmus_counts > Hsap_counts 
 (i.e. candidate mouse cells) and those with Hsap_counts > Mmus_counts (i.e. candidate human cells).
@@ -55,12 +58,14 @@ class CellCaller:
       self.parse_arguments()
       self.read_in_anndata_and_handle_error()
       self.derive_count_threshold()
+      self.generate_pdf_plot()
+      self.generate_barnyard_plot()
 
    def parse_arguments(self):
-      parser = argparse.ArgumentParser(description = "Arguments for cell caller script to calculate count threshold for calling cells")
+      parser = argparse.ArgumentParser(description = "Arguments for cell caller script to calculate count threshold for calling cells.")
       parser.add_argument("--sample_name", help="Sample ID", required=True)
       parser.add_argument("--single_species", help="Whether this is a single species run.", required=True)
-      parser.add_argument("--minimum_count_threshold", default=100, type=float, help="minimal number of counts to call cell")
+      parser.add_argument("--minimum_count_threshold", default=100, type=float, help="Default minimum number of counts to call a barcode a cell in the absence of a dynamically determined threshold.")
       parser.add_argument("--count_matrix", help="Path to the h5ad count matrix.", required=True)
       parser.add_argument("--manual_threshold_str", help="A string of manual thresholds as specified by the user in the optional threshold input csv.", required=True)
       
@@ -76,7 +81,6 @@ class CellCaller:
          self.mixed_species = True
 
       # Extract any user specified cell caller thresholds
-
       if self.mixed_species:
          # Split the input thresholds string on _, the first value is the human threshold, the second is the mouse threshold
          self.manual_thresholds = self.manual_threshold_str.split("_")
@@ -102,7 +106,7 @@ class CellCaller:
       if self.single_species:
          self.log10_counts = np.log10(self.adata.X.sum(axis=1).A1 + 1)
 
-         if len(set(self.log10_counts)) == 1:
+         if len(set(self.log10_counts)) <= 1:
             self.clean_exit_on_error()
          else:
             self.pdf_df = self.get_prob_dens_data(self.log10_counts)
@@ -110,21 +114,21 @@ class CellCaller:
                self.log_cutoff = self.single_species_specified_threshold
             else:
                self.log_cutoff = self.get_cutoff(self.pdf_df)
-
-            self.make_pd_plots()
+               
             # Transform back, and round to the nearest integer
-            print(f"{round(10 ** self.log_cutoff)}", end="")
+            self.single_species_thres = round(10 ** self.log_cutoff -1)
+            print(f"{self.single_species_thres}", end="") 
       else:
          # Identify the sub-populations of barcodes which are: 1) majority human counts and 2) majority mouse counts
          self.hsap_majority = self.adata.obs[self.adata.obs["hsap_counts"] > self.adata.obs["mmus_counts"]]
          self.mmus_majority = self.adata.obs[self.adata.obs["mmus_counts"] > self.adata.obs["hsap_counts"]]
 
-         # Log transform (+1) the total human counts in the majority human population, and the total mouse counts in the majority mouse population  
+         # Log transform the total human counts (+1) in the majority human population, and the total mouse counts (+1) in the majority mouse population  
          self.log10_hsap_counts_hsap_majority = np.log10(self.hsap_majority.hsap_counts+1)
          self.log10_mmus_counts_mmus_majority = np.log10(self.mmus_majority.mmus_counts+1)
 
          # Compute the human and mouse thresholds on a log10 scale, and output the probability density plots
-         if (len(set(self.log10_hsap_counts_hsap_majority)) == 1) or (len(set(self.log10_mmus_counts_mmus_majority)) == 1):
+         if (len(set(self.log10_hsap_counts_hsap_majority)) <= 1) or (len(set(self.log10_mmus_counts_mmus_majority)) <= 1):
             self.clean_exit_on_error()
          else:
             self.hsap_pdf_df = self.get_prob_dens_data(self.log10_hsap_counts_hsap_majority)
@@ -138,18 +142,19 @@ class CellCaller:
             else:
                self.mmus_log_cutoff = self.get_cutoff(self.mmus_pdf_df)
 
-            self.make_pd_plots()
-            hsap_thres = round(10 ** self.hsap_log_cutoff)
-            mmus_thres = round(10 ** self.mmus_log_cutoff)
             # Transform back, and round to the nearest integer
-            print(f"{hsap_thres}_{mmus_thres}", end="")
+            self.hsap_thres = round(10 ** self.hsap_log_cutoff -1)
+            self.mmus_thres = round(10 ** self.mmus_log_cutoff -1)
+            
+            print(f"{self.hsap_thres}_{self.mmus_thres}", end="")
 
    def clean_exit_on_error(self):
       """
-      If we encounter an error we output an empty figure and return the
+      If we encounter an error we output a empty figures and return the
       default minimum_count_threshold in either single or mixed species format
       """
-      open(f"{self.sample_name}_pdf_with_cutoff.png", "w").close()
+      open(f"{self.sample_name}_counts_pdf_with_threshold.html", "w").close()
+      open(f"{self.sample_name}_barnyard_plot.html", "w").close()
       if self.single_species:
          print(int(self.minimum_count_threshold), end="")
       else:
@@ -185,19 +190,19 @@ class CellCaller:
       """
       Calculate and return cutoff
       """
-      # **********************
+      # ----------------------
       # MINIMA IDENTIFICATION
-      # **********************
+      # ----------------------
       # Find the local minima of the probability density curve
       local_minima = argrelextrema(pdf_df['evaluated'].values, np.less, order=1)
       # Find the number of species-specific counts at which the minima occur
       minima_locations = pdf_df['data_space'].values[local_minima]
       # Filter to retain only the minima above the minimum_count_threshold
-      potential_minima_cutoffs = minima_locations[minima_locations >= np.log10(self.minimum_count_threshold)]
+      potential_minima_cutoffs = minima_locations[minima_locations >= np.log10(self.minimum_count_threshold + 1)]
 
-      # ********************************
+      # --------------------------------
       # INFLECTION POINT IDENTIFICATION
-      # ********************************
+      # --------------------------------
       # Calculate the first and second derivatives of the probability density curve to use in identifying suitable inflection points
       first_derivatives = np.diff(pdf_df['evaluated'].values)/np.diff(pdf_df['data_space'].values)
       second_derivatives = np.diff(first_derivatives)/np.diff(pdf_df['data_space'].values[:-1])
@@ -206,74 +211,254 @@ class CellCaller:
       derivatives_df["sign_change"] = np.where(derivatives_df["second_derivative"].shift(1) * derivatives_df["second_derivative"] < 0, 1, 0)
       
       # Find the inflection points which are above the minimum_count_threshold, which also have a gradient close to 0 
-      inflection_points_df = derivatives_df[(derivatives_df["sign_change"] == 1) & (derivatives_df["data_space"] >= np.log10(self.minimum_count_threshold)) & (derivatives_df["first_derivative"].abs() < 0.2)]
+      inflection_points_df = derivatives_df[(derivatives_df["sign_change"] == 1) & (derivatives_df["data_space"] >= np.log10(self.minimum_count_threshold + 1)) & (derivatives_df["first_derivative"].abs() < 0.2)]
       # Find the number of species-specific counts at which the inflection point(s) occur
       potential_inflection_point_cutoffs = inflection_points_df["data_space"].values
 
-      # **********************
+      # --------------------
       # THRESHOLD SELECTION
-      # **********************
+      # --------------------
 
       if len(potential_minima_cutoffs) == 0:
          # If there are no suitable minima but there is a back-up inflection point, select the inflection point
          # Otherwise, default to the minimum_count_threshold
          if len(potential_inflection_point_cutoffs) == 0:
-            log_cutoff = np.log10(self.minimum_count_threshold)
+            log_cutoff = np.log10(self.minimum_count_threshold + 1)
          else:
             log_cutoff = min(potential_inflection_point_cutoffs)
       else:
-         # If there are any minima that are above 2, find the smallest one.
+         # If there are any minima that are above the minimum threshold, find the smallest one.
          log_cutoff = min(potential_minima_cutoffs)
       return log_cutoff
+         
+   def generate_pdf_plot(self):
+      pdf_html_filename = f"{self.sample_name}_counts_pdf_with_threshold.html"
+      if self.single_species:
+         total_counts_pdf_fig = self.pdf_plotter(self.pdf_df, self.log_cutoff, "total")
+         self.output_plot_to_html({f"{self.sample_name}_cellcaller_plot":total_counts_pdf_fig}, pdf_html_filename)
+      else:
+         human_counts_pdf_fig = self.pdf_plotter(self.hsap_pdf_df, self.hsap_log_cutoff, "human")
+         mouse_counts_pdf_fig = self.pdf_plotter(self.mmus_pdf_df, self.mmus_log_cutoff, "mouse")
+         self.output_plot_to_html({f"{self.sample_name}_hsap_cellcaller_plot":human_counts_pdf_fig, f"{self.sample_name}_mmus_cellcaller_plot":mouse_counts_pdf_fig}, 
+                                   pdf_html_filename)
 
-   def make_pd_plots(self):
+   def pdf_plotter(self, input_pdf_df, input_log_cutoff, count_type_str):
       """
-      # TODO convert to plotly.
-      Plot probability density with the default cutoffs
-      and cell caller cutoff, and save the plot as a png
+      Plot probability density with the cell caller cutoff, 
+      and save the plot as an html (two plots for mixed species)
+      """
+
+      title_str = f"Cell caller minimum {count_type_str}-count threshold derived from <br> distribution of {count_type_str} counts"
+      if self.mixed_species:
+         title_str += f" in majority {count_type_str}-count barcodes"
+
+      pdf_fig = px.line(input_pdf_df, 
+                        x="data_space", 
+                        y="evaluated",
+                        labels={"data_space":f"log10({count_type_str}_counts + 1)", "evaluated":"Density"},
+                        title=title_str
+                        )
+      
+      pdf_fig.update_traces(line_color='#0081D4', 
+                            line=dict(width=3),
+                            customdata = [10**x -1 for x in input_pdf_df["data_space"]],
+                            hovertemplate=f"log10({count_type_str}_counts + 1): %{{x:.3f}}<br>{count_type_str}_counts: %{{customdata:.0f}}<br>Density: %{{y:.3f}}"
+                            )
+      
+      pdf_fig.add_vline(x=input_log_cutoff, 
+                        line_color="#36BA00", 
+                        line_width=3
+                        )
+      
+      pdf_fig.add_trace(go.Scatter(x=[input_log_cutoff]*200,
+                                   y=np.linspace(input_pdf_df["evaluated"].min(), input_pdf_df["evaluated"].max(), 200),
+                                   mode='lines',
+                                   name=f"Cell caller threshold =  <br>{str(round(10**input_log_cutoff -1))} {count_type_str} counts",
+                                   line=dict(color = "#36BA00", width=3),  
+                                   hovertemplate=f"Cell caller threshold = {round(input_log_cutoff,3)} (log10 scale)<extra></extra>"
+                                   )
+                        )
+            
+      pdf_fig.update_layout(font=dict(family = 'Lexend, sans-serif', color="black"),
+                            title_x=0.5,
+                            plot_bgcolor="white",
+                            autosize=True,
+                            xaxis = dict(
+                               mirror=True,
+                               ticks='outside',
+                               showline=True,
+                               linecolor='black',
+                               linewidth=3,
+                               tickwidth=3,
+                               tickformat=".1f"
+                               ),
+                            yaxis = dict(
+                               mirror=True,
+                               ticks='outside',
+                               showline=True,
+                               linecolor='black',
+                               linewidth=3,
+                               tickwidth=3,
+                               tickformat=".1f"
+                               ),
+                            legend=dict(
+                               yanchor="top", y=0.99, 
+                               xanchor="right",x=0.99, 
+                               bordercolor="Black",
+                               borderwidth=2,
+                               title=""
+                               )
+                           )
+
+      return pdf_fig
+
+   def output_plot_to_html(self, dict_of_figs_and_names, html_filename):
+      """
+      Output a suite of plots to an html file, incorporating the Lexend font.
+      Expects as input a dictionary of plotly figures and their names.
+      Figure names are used to name the .svg files which can be downloaded from the html.
+      """
+      # Add custom CSS to embed the Lexend font
+      html_content = """
+      <head>
+         <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;700&display=swap" rel="stylesheet">
+      </head>
+      <body>
+      """
+
+      # Add each figure to the HTML content
+      for fig_name in dict_of_figs_and_names.keys():
+         fig = dict_of_figs_and_names[fig_name]
+         html_content += pio.to_html(fig, full_html=False, include_plotlyjs='cdn', config={"responsive": True, 
+                                                                                           'displaylogo': False, 
+                                                                                           'toImageButtonOptions': {'format': 'svg',
+                                                                                                                    'filename': fig_name,
+                                                                                                                    'scale': 1 
+                                                                                                                    }
+                                                                                          })
+
+      # Close the HTML tags
+      html_content += """
+      </body>
+      """
+
+      # Write the HTML content to the file
+      with open(html_filename, "w") as f:
+         f.write(html_content)
+
+   def assign_barcode_type(self, hsap_counts, mmus_counts):
+      """
+      In a mixed-species experiment, barcode-types are assigned based on the following rules:
+
+      Hsap_counts >= Hsap_threshold & Mmus_counts <= Mmus_threshold is a single-cell (human).
+      Mmus_counts >= Mmus_threshold & Hsap_counts <= Hsap_threshold is a single-cell (mouse).
+      Mmus_counts < Mmus_threshold & Hsap_counts < Hsap_threshold is a noisy barcode.
+      Mmus_counts > Mmus_threshold & Hsap_counts > Hsap_threshold is a multiplet.
+      """
+
+      if hsap_counts > self.hsap_thres and mmus_counts > self.mmus_thres:
+         barcode_type = "multiplet" 
+      elif hsap_counts < self.hsap_thres and mmus_counts < self.mmus_thres:
+         barcode_type = "noise"
+      else:
+         barcode_type = "single-cell"
+      return barcode_type
+      
+   def generate_barnyard_plot(self):
+      """
+      Create barnyard plot for mixed species samples. If single species then output an empty html. 
       """
       if self.single_species:
-         plt.plot(self.pdf_df['data_space'], self.pdf_df['evaluated'])
-         plt.axvline(self.log_cutoff, color = 'red', label = f"Cell Caller\n {str(round(10 ** self.log_cutoff))}")
-         plt.axvline(np.log10(self.minimum_count_threshold), color = 'black', label = f"Default\n{str(round(self.minimum_count_threshold))}")
-         plt.title("Cell Caller minimum count\nthreshold calculation", fontdict = {'family':'sans-serif','color':'black','size':12,'fontweight':'bold'})
-         plt.xlabel("log10(total_counts + 1)")
-         plt.ylabel("Density")
-         plt.legend(bbox_to_anchor = (1.0, 1), loc = 'upper right', title="Method", fontsize=7)
-         plt.savefig(f"{self.sample_name}_pdf_with_cutoff.png", dpi=900) 
-         plt.close()    # close the figure window
+         open(f"{self.sample_name}_barnyard_plot.html", "w").close()
       else:
-         # Create a new figure
-         plt.figure(figsize=(7, 10))
+         # Create a new column in the adata object to assign barcode types
+         self.adata.obs["barcode_type"] = self.adata.obs.apply(lambda x:self.assign_barcode_type(x["hsap_counts"], x["mmus_counts"]), axis=1)
+         self.adata.obs["cell_name"] = self.adata.obs.index
 
-         # First subplot for hsap
-         plt.subplot(2, 1, 1)  # (rows, columns, panel number)
-         plt.plot(self.hsap_pdf_df['data_space'], self.hsap_pdf_df['evaluated'])
-         plt.axvline(self.hsap_log_cutoff, color='red', label=f"Cell Caller\n {str(round(10 ** self.hsap_log_cutoff))}")
-         plt.axvline(np.log10(self.minimum_count_threshold), color='black', label=f"Default\n{str(round(self.minimum_count_threshold))}")
-         plt.title("Cell Caller minimum human count threshold calculation\nin majority human-count barcodes", fontdict={'family': 'sans-serif', 'color': 'black', 'size': 12, 'fontweight': 'bold'})
-         plt.xlabel("log10(hsap_counts + 1)")
-         plt.ylabel("Density")
-         plt.legend(bbox_to_anchor=(1.0, 1), loc='upper right', title="Method", fontsize=7)
+         # Set axis upper limit to just higher than the max count of either species 
+         axis_upper_limit = max([self.adata.obs["hsap_counts"].max(), self.adata.obs["mmus_counts"].max()])*1.01
+         # Set axis lower limit to a fixed % below 0 - allows some separation from the axis for better readability
+         axis_lower_limit = 0-(axis_upper_limit*0.02)
 
-         # Second subplot for mmus
-         plt.subplot(2, 1, 2)  # (rows, columns, panel number)
-         plt.plot(self.mmus_pdf_df['data_space'], self.mmus_pdf_df['evaluated'])
-         plt.axvline(self.mmus_log_cutoff, color='red', label=f"Cell Caller\n {str(round(10 ** self.mmus_log_cutoff))}")
-         plt.axvline(np.log10(self.minimum_count_threshold), color='black', label=f"Default\n{str(round(self.minimum_count_threshold))}")
-         plt.title("Cell Caller minimum mouse count threshold calculation\nin majority mouse-count barcodes", fontdict={'family': 'sans-serif', 'color': 'black', 'size': 12, 'fontweight': 'bold'})
-         plt.xlabel("log10(mmus_counts + 1)")
-         plt.ylabel("Density")
-         plt.legend(bbox_to_anchor=(1.0, 1), loc='upper right', title="Method", fontsize=7)
+         barnyard_fig = px.scatter(self.adata.obs, 
+                                 x="mmus_counts", 
+                                 y="hsap_counts", 
+                                 color="barcode_type", 
+                                 labels={"hsap_counts":"Number of counts from human genes", "mmus_counts":"Number of counts from mouse genes", "barcode_type":""},
+                                 title="Barnyard plot of human and mouse counts per barcode",
+                                 opacity=0.7,
+                                 color_discrete_map={"noise": "#9AA3A8", "single-cell":"#36BA00", "multiplet":"#0081D4"},
+                                 custom_data=['cell_name', 'barcode_type']
+                                 )
 
-         # Adjust layout to prevent overlapping content
-         plt.tight_layout()
+         barnyard_fig.update_traces(hovertemplate=(
+                                       "Cell Name: %{customdata[0]}<br>"
+                                       "Barcode Type: %{customdata[1]}<br>"
+                                       "Mouse Counts: %{x:.0f}<br>"
+                                       "Human Counts: %{y:.0f}"
+                                       )
+                                    )
+      
+         barnyard_fig.add_hline(y=self.hsap_thres, 
+                              line_dash="dot", 
+                              line_color="black",
+                              line_width = 1.5,
+                              annotation_position = "bottom right",
+                              annotation_text = f"Hsap threshold = {self.hsap_thres}"
+                              )
 
-         # Save the figure as a single .png image
-         plt.savefig(f"{self.sample_name}_combined_pdf_with_cutoff.png", dpi=900)
+         # Add the threshold legend to the graph
+         barnyard_fig.add_trace(go.Scatter(y=[self.hsap_thres, self.hsap_thres],
+                                          x=[0, 0.1],
+                                          mode='lines',
+                                          name=f"Hsap threshold = {self.hsap_thres}",
+                                          line=dict(dash='dot', color = "black", width=1.5))
+                                 )
+         
+         barnyard_fig.add_vline(x=self.mmus_thres, 
+                           line_dash="dash", 
+                           line_color="black",
+                           line_width = 1.5,
+                           annotation_position = "top right",
+                           annotation_text = f"Mmus threshold = {self.mmus_thres}"
+                           )
+         
+         barnyard_fig.add_trace(go.Scatter(x=[self.mmus_thres, self.mmus_thres],
+                                          y=[0, 0.1],
+                                          mode='lines',
+                                          name=f"Mmus threshold = {self.mmus_thres}",
+                                          line=dict(dash='dash', color = "black", width=1.5))
+                                 )
+      
+         barnyard_fig.update_layout(font=dict(family = 'Lexend, sans-serif', color="black"),
+                                    plot_bgcolor="white",
+                                    margin = dict(l=45,r=45,t=50,b=45),
+                                    autosize=True,
+                                    xaxis = dict(
+                                       range=[axis_lower_limit, axis_upper_limit],
+                                       mirror=True,
+                                       ticks='outside',
+                                       showline=True,
+                                       linecolor='black',
+                                       linewidth=2,
+                                       tickwidth=2,
+                                       gridcolor='lightgrey'
+                                       ),
+                                    yaxis = dict(
+                                       range=[axis_lower_limit, axis_upper_limit],
+                                       mirror=True,
+                                       ticks='outside',
+                                       showline=True,
+                                       linecolor='black',
+                                       linewidth=2,
+                                       tickwidth=2,
+                                       gridcolor='lightgrey'
+                                       )
+                                    )
 
-         # Close the figure window to free up memory
-         plt.close()
+         barnyard_html_filename = f"{self.sample_name}_barnyard_plot.html"
 
+         self.output_plot_to_html({f"{self.sample_name}_barnyard_plot":barnyard_fig}, barnyard_html_filename)
+      
 if __name__ == "__main__":
    CellCaller()

--- a/bin/cell_caller.py
+++ b/bin/cell_caller.py
@@ -150,7 +150,7 @@ class CellCaller:
 
    def clean_exit_on_error(self):
       """
-      If we encounter an error we output a empty figures and return the
+      If we encounter an error, we output empty figures and return the
       default minimum_count_threshold in either single or mixed species format
       """
       open(f"{self.sample_name}_counts_pdf_with_threshold.html", "w").close()

--- a/bin/create_single_sample_report.py
+++ b/bin/create_single_sample_report.py
@@ -36,40 +36,55 @@ class SingleSampleHTMLReport:
     def __init__(self):
         
         self.sample_id = sys.argv[1]
-        self.plot_path = sys.argv[2]
+        self.pdf_plot_path = sys.argv[2]
+        self.barnyard_plot_path = sys.argv[3]
 
         # Create a nested dict grouping by table
         self.metrics_dict = defaultdict(dict)
-        with open(sys.argv[3]) as metrics_handle:
+        with open(sys.argv[4]) as metrics_handle:
             header_line = next(metrics_handle)
             for line in metrics_handle:
                 var_name, var_value, var_human_readable_name, var_tooltip, var_group = line.strip().split(",")
                 self.metrics_dict[var_group][var_name] = (var_human_readable_name, self.format_number_to_string(var_value), var_tooltip)
 
-        with open(sys.argv[4]) as html_template:
+        with open(sys.argv[5]) as html_template:
             self.jinja_template = Template(html_template.read())
 
-        if sys.argv[5].upper() == "TRUE":
+        if sys.argv[6].upper() == "TRUE":
             self.mixed = True
         else:
             self.mixed = False
 
-        # If 'empty' in the name of the Cell Caller plot
-        # then set self.show_cell_caller_plot to False.
-        # Will cause the Cell Caller plot to be hidden.
-        if os.path.getsize(self.plot_path) == 0:
+        # If size of cell caller plot file is 0, then set self.show_cell_caller_plot to False.
+        # This will cause the Cell Caller plot to be hidden.
+        if os.path.getsize(self.pdf_plot_path) == 0:
             self.show_cell_caller_plot=False
-            self.encoded_png_str = None
+            self.pdf_plot = None
             print("Cell Caller plot size is 0. Hiding Cell Caller plot card.")
         else:
             self.show_cell_caller_plot=True
-            self.encoded_png_str = self.generate_encoded_png_str()
+            self.pdf_plot = self.read_html_plot(self.pdf_plot_path)
+
+        # If mixed species and the size of barnyard plot file is 0, 
+        # then set self.show_barnyard_plot to False.
+        # If single species, then set self.show_barnyard_plot to False always.
+        if self.mixed:
+            if os.path.getsize(self.barnyard_plot_path) == 0:
+                self.show_barnyard_plot=False
+                self.barnyard_plot = None
+                print("Barnyard plot size is 0. Hiding Barnyard plot card.")
+            else:
+                self.show_barnyard_plot=True
+                self.barnyard_plot = self.read_html_plot(self.barnyard_plot_path)
+        else:
+            self.show_barnyard_plot=False
+            self.barnyard_plot = None
 
         self.render_and_write_report()
 
-    def generate_encoded_png_str(self):
-        with open(f"{self.plot_path}", "rb") as image_file:
-            return base64.b64encode(image_file.read()).decode("utf-8")
+    def read_html_plot(self, path):
+        with open(f"{path}", "r", encoding="utf-8") as html_file:
+            return html_file.read()
 
     def render_and_write_report(self):
         # For mixed species cell metrics we need to create 'cell_stat_cat_dict'.
@@ -90,10 +105,11 @@ class SingleSampleHTMLReport:
 
         cell_stat_cat_dict_obj = get_cell_stat_cat_dict_obj(self.mixed)
 
-
         final_report = self.jinja_template.render(metrics_dict=self.metrics_dict,
                                             show_cell_caller_plot=self.show_cell_caller_plot,
-                                            encoded_png_str=self.encoded_png_str,
+                                            pdf_plot=self.pdf_plot,
+                                            show_barnyard_plot=self.show_barnyard_plot,
+                                            barnyard_plot=self.barnyard_plot,
                                             sample_id=self.sample_id,
                                             mixed = self.mixed,
                                             # These dicts are required to supply the tooltips, the accordion header ID and the collapse ID for each of the categories of alignment statistics
@@ -104,8 +120,8 @@ class SingleSampleHTMLReport:
                                             alignment_cat_dict = {
                                                 "Post read QC alignment": ("Mapping of the post QC reads i.e. after trimming (polyX end and internal polyA) and barcode verification.", "qc_accord_header", "qc_collapse"),
                                                 "Annotated reads alignment": ("High confidence reads annotated with a gene ID (XT bam tag).", "ann_accord_header", "ann_collapse")
-                                                },  cell_stat_cat_dict = cell_stat_cat_dict_obj)
-
+                                            },  
+                                            cell_stat_cat_dict = cell_stat_cat_dict_obj)
 
         # Write out the rendered template.
         with open(f"{self.sample_id}_report.html", "w") as f_output:

--- a/conf/images.config
+++ b/conf/images.config
@@ -22,10 +22,10 @@ process {
     withName: sort_index_bam        { container = 'quay.io/biocontainers/samtools:1.17--hd87286a_1' }
     withName: single_sample_multiqc { container = 'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }
     withName: multi_sample_multiqc  { container = 'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }
-    withName: count_matrix          { container = 'quay.io/csgenetics/scanpy_anndata:0.0.3' }
-    withName: cell_caller           { container = 'quay.io/csgenetics/scanpy_anndata:0.0.3' }
-    withName: filter_count_matrix   { container = 'quay.io/csgenetics/scanpy_anndata:0.0.3' }
-    withName: summary_statistics	{ container = 'quay.io/csgenetics/scanpy_anndata:0.0.3' }
+    withName: count_matrix          { container = 'quay.io/csgenetics/scanpy_anndata:0.0.4' }
+    withName: cell_caller           { container = 'quay.io/csgenetics/scanpy_anndata:0.0.4' }
+    withName: filter_count_matrix   { container = 'quay.io/csgenetics/scanpy_anndata:0.0.4' }
+    withName: summary_statistics	{ container = 'quay.io/csgenetics/scanpy_anndata:0.0.4' }
     withName: multi_sample_report   { container = 'quay.io/csgenetics/html_build:0.0.2' }
     withName: single_summary_report { container = 'quay.io/csgenetics/html_build:0.0.2' }
 }

--- a/main.nf
+++ b/main.nf
@@ -362,10 +362,10 @@ workflow {
   // Generate summary statistics
   summary_statistics(ch_summary_statistics_in)
 
-  ch_summary_metrics_and_plot = summary_statistics.out.metrics_csv.join(cell_caller.out.cell_caller_plot, by:0)
+  ch_summary_metrics_and_plots = summary_statistics.out.metrics_csv.join(cell_caller.out.cell_caller_plots, by:0)
 
   // Generate single sample report
-  single_summary_report(ch_summary_metrics_and_plot, single_sample_report_template)
+  single_summary_report(ch_summary_metrics_and_plots, single_sample_report_template)
 
   // Generate multi sample report
   multi_sample_report(single_summary_report.out.single_sample_metric_out.collect(), multi_sample_report_template)

--- a/modules/processes.nf
+++ b/modules/processes.nf
@@ -726,14 +726,12 @@ process count_matrix {
 process cell_caller {
   tag "$sample_id"
 
-  publishDir "${params.outdir}/plots", pattern: "${sample_id}_pdf_with_cutoff.png", mode: 'copy'
-
   input:
   tuple val(sample_id), path(count_matrix_h5ad), val(manual_threshold_str)
 
   output:
   tuple val(sample_id), stdout, emit: cell_caller_out
-  tuple val(sample_id), path("${sample_id}*_pdf_with_cutoff.png"), emit: cell_caller_plot
+  tuple val(sample_id), path("${sample_id}*_counts_pdf_with_threshold.html"), path("${sample_id}*_barnyard_plot.html"), emit: cell_caller_plots
 
   script:
   """
@@ -801,7 +799,7 @@ process single_summary_report {
   publishDir "${params.outdir}/report/${sample_id}", mode: 'copy'
   
   input:
-  tuple val(sample_id), path(metrics_csv), path(plot_png)
+  tuple val(sample_id), path(metrics_csv), path(pdf_plot_html), path(barnyard_plot_html)
   path(html_template)
 
   output:
@@ -810,7 +808,7 @@ process single_summary_report {
 
   script:
   """
-  create_single_sample_report.py $sample_id $plot_png $metrics_csv $html_template ${params.mixed_species}
+  create_single_sample_report.py $sample_id $pdf_plot_html $barnyard_plot_html $metrics_csv $html_template ${params.mixed_species}
   """
 }
 

--- a/templates/single_sample_report_template.html.jinja2
+++ b/templates/single_sample_report_template.html.jinja2
@@ -21,10 +21,6 @@
     .card,.headline-stat{
       margin-bottom: 1rem;
     }
-    .plotly-div {
-      width: 100%;
-      height: auto;
-    }
   </style>
  </head>
  <body>

--- a/templates/single_sample_report_template.html.jinja2
+++ b/templates/single_sample_report_template.html.jinja2
@@ -21,6 +21,10 @@
     .card,.headline-stat{
       margin-bottom: 1rem;
     }
+    .plotly-div {
+      width: 100%;
+      height: auto;
+    }
   </style>
  </head>
  <body>
@@ -80,7 +84,7 @@
   <!-- Second row; contains remainder of the stats distributed in two columns -->
   <div class="row">
     <!-- First col contains three cards -->
-    <div class="col">
+    <div class="col-6">
       <!-- Will create a card for each of Read QC and Deduplication -->
       {% for first_col_stat in ["Read QC", "Deduplication"] %}
         <div class="card border-left-success shadow py-2">
@@ -110,18 +114,20 @@
       {% endfor %}
 
       {% if show_cell_caller_plot %}
-      <!-- Cell caller plot -->
-      <div class="card border-left-success shadow py-2">
-        <div class="card-body">
-        <img alt='...' class='img-fluid' src='data:image/png;base64,{{ encoded_png_str }}'/>
+        <!-- Cell caller plot -->
+        <div class="card border-left-success shadow py-2">
+          <div class="card-body">
+            <div style="max-width: 100%; max-height: 100%; overflow: hidden; width: auto; height: auto;">
+              {{ pdf_plot | safe }}
+            </div>
+          </div>
         </div>
-      </div>
       {% endif %}
 
     </div>
 
     <!-- Second col contains alignment and cell stats -->
-    <div class="col">
+    <div class="col-6">
       <!-- Cell stats -->
       <div class="card border-left-success shadow py-2">
         <div class="card-body">
@@ -187,9 +193,20 @@
                   </tbody>
                 </table>
               {% endif %}
-        </div>
-      </div>
 
+        </div>
+
+      </div>
+      {% if show_barnyard_plot %}
+      <!-- Barnyard plot -->
+        <div class="card border-left-success shadow py-2">
+          <div class="card-body">
+            <div style="max-width: 100%; max-height: 100%; overflow: hidden; width: auto; height: auto;">
+              {{ barnyard_plot | safe }}
+            </div>
+          </div>
+        </div>
+      {% endif %}
     </div>
 
   </div>


### PR DESCRIPTION
Summary of changes:

- Move to using plotly for all graphs output from cell_caller.py
- Add a barnyard plot output for mixed species pipeline runs (hsap/mmus)
- Adjust all back-transformations from log10 space to account for the '+1' in the original transform i.e. log10(counts + 1)
- No longer write plots out to a results directory. Instead, the new plotly plots are piped straight into the html summary reports from which they can be downloaded as .svg files

The scanpy_anndata container used by the cell_caller process has been updated to include plotly. 

Test pipeline results are available on Jira:
- CS-2210 for human-only
- CS-2211 for mixed-species