### PR TITLE
Output raw count matrix from filter_count_matrix

### DIFF
--- a/modules/processes.nf
+++ b/modules/processes.nf
@@ -711,7 +711,6 @@ process io_count {
 process count_matrix {
   tag "$sample_id"
 
-  publishDir "${params.outdir}/count_matrix/raw_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "*.raw_feature_bc_matrix.h5ad"
   publishDir "${params.outdir}/count_matrix/raw_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "matrix.mtx.gz"
   publishDir "${params.outdir}/count_matrix/raw_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "barcodes.tsv.gz"
   publishDir "${params.outdir}/count_matrix/raw_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "features.tsv.gz"
@@ -768,6 +767,7 @@ process filter_count_matrix{
   publishDir "${params.outdir}/count_matrix/filtered_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "matrix.mtx.gz"
   publishDir "${params.outdir}/count_matrix/filtered_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "barcodes.tsv.gz"
   publishDir "${params.outdir}/count_matrix/filtered_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "features.tsv.gz"
+  publishDir "${params.outdir}/count_matrix/raw_feature_bc_matrix/${sample_id}/", mode: 'copy', pattern: "*.raw_feature_bc_matrix.h5ad"
 
   input:
   tuple val(sample_id), val(count_threshold), path(h5ad_raw_count_matrix)


### PR DESCRIPTION
Outputs the raw count matrix from the `filter_count_matrix` rather than the `count_matrix` process so that the `is_single_cell` `.obs` column is present.

I have run the pipeline through the test config and checked the output to verify that the raw count tables are present and that they contain the `is_single_cell` column in the `.obs` DataFrame.