### PR TITLE
Add claude-yolo shorthand for --dangerously-skip-permissions

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -63,6 +63,13 @@ RUN case "$(dpkg --print-architecture)" in \
 # TODO: pin to a specific version for reproducibility
 RUN npm install -g @anthropic-ai/claude-code && claude --version
 
+# Shorthand for `claude --dangerously-skip-permissions`. Safe inside this
+# container because the container is the blast-radius boundary (see
+# docs/agent-containerisation.md).
+RUN printf '#!/bin/sh\nexec claude --dangerously-skip-permissions "$@"\n' \
+      > /usr/local/bin/claude-yolo \
+ && chmod 0755 /usr/local/bin/claude-yolo
+
 # Entrypoint and helpers (owned by root, world-executable, read-only for agent)
 COPY docker/agent/entrypoint.sh           /usr/local/bin/entrypoint.sh
 COPY docker/agent/gh-credential-helper.sh /usr/local/bin/gh-credential-helper.sh


### PR DESCRIPTION
## Summary
- Adds a `/usr/local/bin/claude-yolo` wrapper script to the agent container image that execs `claude --dangerously-skip-permissions "$@"`.
- Saves operators from looking up the exact flag wording every interactive session. Safe inside the container because the container is the blast-radius boundary (see `docs/agent-containerisation.md` in csgenetics/GRT).

## Test plan
- [ ] Image rebuilds cleanly with the existing build command from `docker/agent/Dockerfile`.
- [ ] After next persistent-container relaunch, `which claude-yolo` resolves and `claude-yolo --version` reports the same version as `claude --version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)